### PR TITLE
Squash DRF deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ language: python
 matrix:
   include:
   - python: 3.5
-    env: TOX_ENV=py35-django22-celery44
+    env: TOX_ENV=py35-django22-celery44-drf39
   - python: 3.8
-    env: TOX_ENV=py38-django22-celery44
+    env: TOX_ENV=py38-django22-celery44-drf39
+  - python: 3.8
+    env: TOX_ENV=py38-django22-celery44-drf310
+  - python: 3.8
+    env: TOX_ENV=py38-django22-celery44-drf311
+  - python: 3.8
+    env: TOX_ENV=py38-django22-celery44-drf312
   - python: 3.8
     env: TOX_ENV=quality
   - python: 3.8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Unreleased
 
 *
 
+[1.3.1] - 2020-11-23
+~~~~~~~~~~~~~~~~~~~~
+
+Added
++++++
+
+* Added support for Django REST Framework 3.10.x through 3.12.x
+
 [1.3.0] - 2020-08-25
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,10 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/quality.txt requirements/quality.in
 	$(PIP_COMPILE) -o requirements/travis.txt requirements/travis.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
-	# Let tox control the Django and celery versions for tests
+	# Let tox control the Django, djangorestframework, and celery versions for tests
 	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==" requirements/base.txt > requirements/celery44.txt
 	sed -i.tmp '/^[dD]jango==/d' requirements/test.txt
+	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
 	sed -i.tmp '/^amqp==/d' requirements/test.txt
 	sed -i.tmp '/^anyjson==/d' requirements/test.txt
 	sed -i.tmp '/^billiard==/d' requirements/test.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,8 @@ amqp==2.6.1               # via kombu
 billiard==3.6.3.0         # via celery
 celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
 django-model-utils==4.0.0  # via -r requirements/base.in
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils
-djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework
+djangorestframework==3.12.2  # via -r requirements/base.in
 importlib-metadata==2.0.0  # via kombu
 kombu==4.6.11             # via celery
 pytz==2020.4              # via celery, django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,7 +13,3 @@ celery<5.0
 
 # Stay on an LTS release
 django<2.3
-
-# Requires work, including removal of detail_route. See:
-# https://www.django-rest-framework.org/community/3.8-announcement/#action-decorator-replaces-list_route-and-detail_route
-djangorestframework<3.10.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,8 +18,8 @@ codecov==2.1.10           # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 django-model-utils==4.0.0  # via -r requirements/test.txt
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, edx-i18n-tools
-djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/test.txt
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt, django-model-utils, djangorestframework, edx-i18n-tools
+djangorestframework==3.12.2  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,8 +18,8 @@ coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 django-model-utils==4.0.0  # via -r requirements/base.txt
 django-rest-swagger==2.2.0  # via -r requirements/doc.in
-django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-model-utils
-djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt, django-rest-swagger
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, django-model-utils, djangorestframework
+djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,6 @@
 attrs==20.3.0             # via pytest
 coverage==5.3             # via pytest-cov
 django-model-utils==4.0.0  # via -r requirements/base.txt
-djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt
 importlib-metadata==2.0.0  # via -r requirements/base.txt, kombu, pytest
 iniconfig==1.1.1          # via pytest
 mock==3.0.5               # via -r requirements/test.in

--- a/test_settings.py
+++ b/test_settings.py
@@ -12,7 +12,8 @@ from celery import __version__ as celery_version
 from packaging import version
 
 CELERY_VERSION = version.parse(celery_version)
-results_dir = tempfile.TemporaryDirectory()
+MEDIA_DIR = tempfile.TemporaryDirectory()
+RESULTS_DIR = tempfile.TemporaryDirectory()
 
 
 def root(*args):
@@ -31,7 +32,7 @@ BROKER_URL = 'memory://localhost/'
 CELERY_IGNORE_RESULT = True
 
 if CELERY_VERSION >= version.parse('4.0'):
-    CELERY_RESULT_BACKEND = 'file://{}'.format(results_dir.name)
+    CELERY_RESULT_BACKEND = 'file://{}'.format(RESULTS_DIR.name)
 
 DATABASES = {
     'default': {
@@ -58,7 +59,7 @@ LOCALE_PATHS = [
     root('user_tasks', 'conf', 'locale'),
 ]
 
-MEDIA_ROOT = tempfile.mkdtemp()
+MEDIA_ROOT = MEDIA_DIR.name
 
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ Configuration code for pytest runs.
 import pytest
 from celery import Celery
 
+from django.conf import settings
+
 
 @pytest.fixture(autouse=True, scope='session')
 def start_celery_app():
@@ -22,6 +24,13 @@ def manage_temp_dirs():
     Explicitly clean up the temporary directories created in test_settings.py when the test session ends.
     """
     yield
-    from django.conf import settings
-    settings.MEDIA_DIR.cleanup()
-    settings.RESULTS_DIR.cleanup()
+    # The try/except blocks are to work around a Python 3.5 bug: https://bugs.python.org/issue22427
+    # They can be removed once we stop testing under Python 3.5 in edx-platform (coming soon)
+    try:
+        settings.MEDIA_DIR.cleanup()
+    except FileNotFoundError:
+        pass
+    try:
+        settings.RESULTS_DIR.cleanup()
+    except FileNotFoundError:
+        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,14 @@ def start_celery_app():
     app = Celery('user_tasks')
     app.conf.task_protocol = 1
     app.config_from_object('django.conf:settings')
+
+
+@pytest.fixture(autouse=True, scope='session')
+def manage_temp_dirs():
+    """
+    Explicitly clean up the temporary directories created in test_settings.py when the test session ends.
+    """
+    yield
+    from django.conf import settings
+    settings.MEDIA_DIR.cleanup()
+    settings.RESULTS_DIR.cleanup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox]
-envlist = py35-django22-celery{44},py38-django{22,30}-celery{44}
+envlist = py35-django22-celery{44}-drf39,py38-django{22,30}-celery{44}-drf{39,310,311,312}
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    drf39: djangorestframework>=3.9,<3.10
+    drf310: djangorestframework>=3.10,<3.11
+    drf311: djangorestframework>=3.11,<3.12
+    drf312: djangorestframework>=3.12,<3.13
     celery44: -r{toxinidir}/requirements/celery44.txt
     -r{toxinidir}/requirements/test.txt
 commands =

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 

--- a/user_tasks/urls.py
+++ b/user_tasks/urls.py
@@ -7,7 +7,7 @@ from rest_framework.routers import SimpleRouter
 from user_tasks.views import ArtifactViewSet, StatusViewSet
 
 ROUTER = SimpleRouter()
-ROUTER.register(r'artifacts', ArtifactViewSet, base_name='usertaskartifact')
-ROUTER.register(r'tasks', StatusViewSet, base_name='usertaskstatus')
+ROUTER.register(r'artifacts', ArtifactViewSet, basename='usertaskartifact')
+ROUTER.register(r'tasks', StatusViewSet, basename='usertaskstatus')
 
 urlpatterns = ROUTER.urls

--- a/user_tasks/views.py
+++ b/user_tasks/views.py
@@ -3,7 +3,7 @@ REST API endpoints.
 """
 
 from rest_framework import mixins, permissions, viewsets
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from .conf import settings
@@ -54,7 +54,7 @@ class StatusViewSet(
     queryset = UserTaskStatus.objects.order_by('-created')
     serializer_class = StatusSerializer
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def cancel(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """
         Cancel the task associated with the specified status record.


### PR DESCRIPTION
The test suite had been reporting 3 deprecation warnings (which were preventing a Django REST Framework upgrade) and a ResourceWarning:

```
user_tasks/views.py:57
  /home/travis/build/edx/django-user-tasks/user_tasks/views.py:57: RemovedInDRF310Warning: `detail_route` is deprecated and will be removed in 3.10 in favor of `action`, which accepts a `detail` bool. Use `@action(detail=True)` instead.
    @detail_route(methods=['post'])

user_tasks/urls.py:10
  /home/travis/build/edx/django-user-tasks/user_tasks/urls.py:10: RemovedInDRF311Warning: The `base_name` argument is pending deprecation in favor of `basename`.
    ROUTER.register(r'artifacts', ArtifactViewSet, base_name='usertaskartifact')

user_tasks/urls.py:11
  /home/travis/build/edx/django-user-tasks/user_tasks/urls.py:11: RemovedInDRF311Warning: The `base_name` argument is pending deprecation in favor of `basename`.
    ROUTER.register(r'tasks', StatusViewSet, base_name='usertaskstatus')

/opt/python/3.8.0/lib/python3.8/tempfile.py:816: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpxp8ex7s_'>
  _warnings.warn(warn_message, ResourceWarning)
```

The DRF deprecation warnings were also appearing in the edx-platform test suite, since it uses this package.  This should pave the way to upgrading DRF in edx-platform to at least 3.11, since these were the last deprecation warnings reporting breakage that would occur with that version.

```
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/views.py:57
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/views.py:57
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/views.py:57
21:39:22    /home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/views.py:57: RemovedInDRF310Warning: `detail_route` is deprecated and will be removed in 3.10 in favor of `action`, which accepts a `detail` bool. Use `@action(detail=True)` instead.
21:39:22      @detail_route(methods=['post'])
21:39:22  
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:10
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:10
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:10
21:39:22    /home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:10: RemovedInDRF311Warning: The `base_name` argument is pending deprecation in favor of `basename`.
21:39:22      ROUTER.register(r'artifacts', ArtifactViewSet, base_name='usertaskartifact')
21:39:22  
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:11
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:11
21:39:22  ../../edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:11
21:39:22    /home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/user_tasks/urls.py:11: RemovedInDRF311Warning: The `base_name` argument is pending deprecation in favor of `basename`.
21:39:22      ROUTER.register(r'tasks', StatusViewSet, base_name='usertaskstatus')
```

Implementation notes:
* The changes to DRF usage are exact equivalents to the previous code, behavior shouldn't change.
* Added testing with each major DRF version from 3.9.x (used in edx-platform) to the latest 3.12.x
* Using a pytest session fixture to clean up the temporary directories when the test session ends.  I had to upper case the variable names for them to be importable via `from django.conf import settings`, since `test_settings.py` itself isn't in an importable location.