### PR TITLE
Replace rest_framework_swagger with drf_yasg

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,11 +8,11 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.0.1
+coverage==6.3.2
     # via codecov
 distlib==0.3.3
     # via virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,7 @@ certifi==2021.10.8
     # via
     #   -r requirements/ci.txt
     #   requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.12
     # via
     #   -r requirements/ci.txt
     #   requests
@@ -55,7 +55,7 @@ code-annotations==1.2.0
     #   edx-lint
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==6.0.1
+coverage[toml]==6.3.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -137,7 +137,7 @@ pep517==0.11.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.3.1
+pip-tools==6.6.0
     # via -r requirements/pip-tools.txt
 platformdirs==2.4.0
     # via
@@ -159,7 +159,7 @@ py==1.10.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.txt
 pydocstyle==6.1.1
     # via -r requirements/quality.txt

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -3,10 +3,9 @@
 
 -r base.txt               # Core dependencies for this package
 
-django-rest-swagger       # Generates a Swagger/Open API schema for the REST API
+drf-yasg                  # Generates a Swagger/Open API schema for the REST API
 doc8                      # reStructuredText style checker
 edx-sphinx-theme          # edX theme for Sphinx output
 rules                     # Needed to import user_tasks/rules.py for autodoc
 Sphinx                    # Documentation builder
-swagger2rst               # Generates REST API documentation for Sphinx from a Swagger/Open API schema JSON file
 twine                     # Validates the generated long description for PyPI

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,11 @@ amqp==2.6.1
     # via
     #   -r requirements/base.txt
     #   kombu
-attrs==21.2.0
+asgiref==3.5.0
+    # via
+    #   -r requirements/base.txt
+    #   django
+attrs==21.4.0
     # via jsonschema
 babel==2.9.1
     # via sphinx
@@ -22,7 +26,7 @@ bleach==4.1.0
     # via readme-renderer
 cached-property==1.5.2
     # via swagger2rst
-celery==4.4.7
+celery==5.2.6
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -30,17 +34,15 @@ certifi==2021.10.8
     # via requests
 cffi==1.14.6
     # via cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.12
     # via requests
 colorama==0.4.4
     # via twine
 coreapi==2.3.3
-    # via
-    #   django-rest-swagger
-    #   openapi-codec
+    # via drf-yasg
 coreschema==0.0.4
     # via coreapi
-cryptography==35.0.0
+cryptography==36.0.2
     # via secretstorage
 django==2.2.24
     # via
@@ -48,15 +50,15 @@ django==2.2.24
     #   -r requirements/base.txt
     #   django-model-utils
     #   djangorestframework
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/doc.in
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-doc8==0.9.1
+doc8==0.11.1
     # via -r requirements/doc.in
 docutils==0.17.1
     # via
@@ -64,6 +66,8 @@ docutils==0.17.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
+drf-yasg==1.20.0
+    # via -r requirements/doc.in
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
 idna==3.2
@@ -74,6 +78,8 @@ importlib-metadata==4.8.1
     # via
     #   keyring
     #   twine
+importlib-resources==5.7.1
+    # via jsonschema
 itypes==1.2.0
     # via coreapi
 jeepney==0.7.1
@@ -85,9 +91,9 @@ jinja2==3.0.2
     #   coreschema
     #   sphinx
     #   swagger2rst
-jsonschema==4.1.0
+jsonschema==4.4.0
     # via swagger2rst
-keyring==23.2.1
+keyring==23.5.0
     # via twine
 kombu==4.6.11
     # via
@@ -97,11 +103,9 @@ markupsafe==2.0.1
     # via jinja2
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.0
-    # via
-    #   bleach
-    #   sphinx
-pbr==5.6.0
+packaging==21.3
+    # via sphinx
+pbr==5.8.1
     # via stevedore
 pkginfo==1.7.1
     # via twine
@@ -114,17 +118,19 @@ pygments==2.10.0
     #   sphinx
 pyparsing==2.4.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   babel
     #   celery
     #   django
 pyyaml==5.4.1
-    # via swagger2rst
-readme-renderer==30.0
+    # via
+    #   -c requirements/constraints.txt
+    #   swagger2rst
+readme-renderer==35.0
     # via twine
 requests==2.26.0
     # via
@@ -138,11 +144,11 @@ restructuredtext-lint==1.3.2
     # via doc8
 rfc3986==1.5.0
     # via twine
-rules==3.0
+rules==3.3
     # via -r requirements/doc.in
 secretstorage==3.3.1
     # via keyring
-simplejson==3.17.5
+simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -176,9 +182,7 @@ strict-rfc3339==0.7
     # via swagger2rst
 swagger2rst==0.0.4
     # via -r requirements/doc.in
-tqdm==4.62.3
-    # via twine
-twine==3.4.2
+twine==4.0.0
     # via -r requirements/doc.in
 uritemplate==4.0.0
     # via coreapi

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.1
+pip-tools==6.6.0
     # via -r requirements/pip-tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,9 @@ wheel==0.37.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.4
+pip==22.0.4
     # via -r requirements/pip.in
-setuptools==58.2.0
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -35,7 +35,7 @@ pbr==5.6.0
     # via stevedore
 platformdirs==2.4.0
     # via pylint
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,7 +15,24 @@ attrs==21.2.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-coverage[toml]==6.0.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+coverage[toml]==6.3.2
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/schema/settings.py
+++ b/schema/settings.py
@@ -10,7 +10,7 @@ DEBUG = True
 
 INSTALLED_APPS += (
     'django.contrib.staticfiles',
-    'rest_framework_swagger',
+    'drf_yasg',
 )
 
 MIDDLEWARE = (

--- a/schema/urls.py
+++ b/schema/urls.py
@@ -5,12 +5,25 @@ URLs for REST API schema generation.
 from django.conf.urls import include, url
 from django.contrib import admin
 
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from rest_framework import permissions
+
 from user_tasks.urls import urlpatterns as base_patterns
 
-from .views import swagger
+SCHEMA = get_schema_view(
+   openapi.Info(
+      title="Django User Tasks API",
+      default_version='v1',
+      description="Django User Tasks API docs",
+   ),
+   public=False,
+   permission_classes=[permissions.AllowAny],
+)
 
 # The Swagger/Open API JSON file can be found at http://localhost:8000/?format=openapi
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    url('^$', swagger),
+    url(r'^swagger(?P<format>\.json|\.yaml)$', SCHEMA.without_ui(cache_timeout=0), name='schema-json'),
+    url(r'^swagger/$', SCHEMA.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ] + base_patterns

--- a/schema/urls.py
+++ b/schema/urls.py
@@ -4,11 +4,9 @@ URLs for REST API schema generation.
 
 from django.conf.urls import include, url
 from django.contrib import admin
-
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 from rest_framework import permissions
-
 from user_tasks.urls import urlpatterns as base_patterns
 
 SCHEMA = get_schema_view(


### PR DESCRIPTION
This PR was created following edx/upgrades#17 to switch django rest swagger to drf-yasg