### PR TITLE
feat!: bump celery and drop python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [django32-celery44-drf312, django32-celery44-drflatest, django32-celery50-drf312, 
-          django32-celery50-drflatest, django40-celery44-drf312, django40-celery44-drflatest,
-          django40-celery50-drf312, django40-celery50-drflatest, quality, docs]
+        toxenv: [django32-celery44-drf312, django32-celery44-drflatest, django32-celery52-drf312,
+          django32-celery52-drflatest, django40-celery44-drf312, django40-celery44-drflatest,
+          django40-celery52-drf312, django40-celery52-drflatest, quality, docs]
 
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django32-celery50-drf312'
+      if: matrix.python-version == '3.8' && matrix.toxenv == 'django32-celery52-drf312'
       uses: codecov/codecov-action@v1
       with:
         flags: unittests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-*
+Removed
++++++++
+
+* Removed Python 3.5 support.
+
+Chore
++++++
+
+* Upgraded celery to latest 5.x version.
 
 [2.2.0] - 2022-01-26
 ~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django, djangorestframework, and celery versions for tests
-	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery44.txt
+	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery52.txt
 	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
 	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
 	sed -i.tmp '/^amqp==/d' requirements/test.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,16 +4,28 @@
 #
 #    make upgrade
 #
-amqp==2.6.1
+amqp==5.0.9
     # via kombu
 asgiref==3.5.0
     # via django
 billiard==3.6.4.0
     # via celery
-celery==4.4.7
+celery==5.2.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+click==8.0.3
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.0
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
 django==3.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -24,16 +36,26 @@ django-model-utils==4.2.0
     # via -r requirements/base.in
 djangorestframework==3.13.1
     # via -r requirements/base.in
-kombu==4.6.11
+kombu==5.2.3
     # via celery
+prompt-toolkit==3.0.27
+    # via click-repl
 pytz==2021.3
     # via
     #   celery
     #   django
     #   djangorestframework
+six==1.16.0
+    # via click-repl
 sqlparse==0.4.2
     # via django
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,0 @@
-amqp==5.0.2               # via kombu
-billiard==3.6.3.0         # via celery
-celery==5.0.5             # via -c requirements/constraints.txt, -r requirements/base.in
-click-didyoumean==0.0.3   # via celery
-click-repl==0.1.6         # via celery
-click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl
-kombu==5.0.2              # via celery
-prompt-toolkit==3.0.8     # via click-repl
-vine==5.0.0               # via amqp, celery

--- a/requirements/celery52.txt
+++ b/requirements/celery52.txt
@@ -1,0 +1,9 @@
+amqp==5.0.9
+billiard==3.6.4.0
+celery==5.2.3
+click==8.0.3
+click-didyoumean==0.3.0
+click-repl==0.2.0
+kombu==5.2.3
+prompt-toolkit==3.0.27
+vine==5.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,8 +12,7 @@
 # This file contains all common constraints for edx-repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-# v 5.0 drops support of python3.5
-celery<5.0
+celery<6.0
 
 # pyyaml==6.0 made the `Loader` a necessary argument for `yaml.load()` function.
 # swagger2rst uses pyyaml and fails with the new version hence failing the `make docs` command.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-amqp==2.6.1
+amqp==5.0.9
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -25,7 +25,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
-celery==4.4.7
+celery==5.2.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -41,14 +41,31 @@ click==8.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   celery
+    #   click-didyoumean
     #   click-log
+    #   click-plugins
+    #   click-repl
     #   code-annotations
     #   edx-lint
     #   pip-tools
+click-didyoumean==0.3.0
+    # via
+    #   -r requirements/test.txt
+    #   celery
 click-log==0.3.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+click-plugins==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/test.txt
+    #   celery
 code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
@@ -103,7 +120,7 @@ jinja2==3.0.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-kombu==4.6.11
+kombu==5.2.3
     # via
     #   -r requirements/test.txt
     #   celery
@@ -137,7 +154,7 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.5.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.txt
 platformdirs==2.4.1
     # via
@@ -153,6 +170,10 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
+prompt-toolkit==3.0.27
+    # via
+    #   -r requirements/test.txt
+    #   click-repl
 py==1.11.0
     # via
     #   -r requirements/ci.txt
@@ -223,6 +244,8 @@ six==1.16.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   click-repl
     #   edx-lint
     #   tox
     #   virtualenv
@@ -250,7 +273,7 @@ toml==0.10.2
     #   -r requirements/quality.txt
     #   pylint
     #   tox
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
@@ -272,15 +295,20 @@ urllib3==1.26.8
     # via
     #   -r requirements/ci.txt
     #   requests
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/test.txt
     #   amqp
     #   celery
+    #   kombu
 virtualenv==20.13.1
     # via
     #   -r requirements/ci.txt
     #   tox
+wcwidth==0.2.5
+    # via
+    #   -r requirements/test.txt
+    #   prompt-toolkit
 wheel==0.37.1
     # via
     #   -r requirements/pip-tools.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-amqp==2.6.1
+amqp==5.0.9
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -26,16 +26,33 @@ bleach==4.1.0
     # via readme-renderer
 cached-property==1.5.2
     # via swagger2rst
-celery==4.4.7
+celery==5.2.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
 certifi==2021.10.8
     # via requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.11
     # via requests
+click==8.0.3
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
 colorama==0.4.4
     # via twine
 coreapi==2.3.3
@@ -44,8 +61,6 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==36.0.1
-    # via secretstorage
 django==3.2.12
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -83,10 +98,6 @@ importlib-resources==5.4.0
     # via jsonschema
 itypes==1.2.0
     # via coreapi
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.3
     # via
     #   coreschema
@@ -96,7 +107,7 @@ jsonschema==4.4.0
     # via swagger2rst
 keyring==23.5.0
     # via twine
-kombu==4.6.11
+kombu==5.2.3
     # via
     #   -r requirements/base.txt
     #   celery
@@ -112,8 +123,10 @@ pbr==5.8.1
     # via stevedore
 pkginfo==1.8.2
     # via twine
-pycparser==2.21
-    # via cffi
+prompt-toolkit==3.0.27
+    # via
+    #   -r requirements/base.txt
+    #   click-repl
 pygments==2.11.2
     # via
     #   doc8
@@ -150,13 +163,13 @@ rfc3986==2.0.0
     # via twine
 rules==3.1
     # via -r requirements/doc.in
-secretstorage==3.3.1
-    # via keyring
 simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
+    #   -r requirements/base.txt
     #   bleach
+    #   click-repl
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
@@ -196,14 +209,22 @@ urllib3==1.26.8
     # via
     #   requests
     #   twine
-vine==1.3.0
+vine==5.0.0
     # via
     #   -r requirements/base.txt
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via
+    #   -r requirements/base.txt
+    #   prompt-toolkit
 webencodings==0.5.1
     # via bleach
 zipp==3.7.0
     # via
     #   importlib-metadata
     #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.5.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.in
-tomli==2.0.0
+tomli==2.0.1
     # via pep517
 wheel==0.37.1
     # via pip-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,6 +19,23 @@ attrs==21.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.2.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
 coverage[toml]==6.3.1
     # via pytest-cov
     # via
@@ -42,6 +59,9 @@ packaging==21.3
     #   pytest
 pluggy==1.0.0
     # via pytest
+    # via
+    #   -r requirements/base.txt
+    #   click-repl
 py==1.11.0
     # via pytest
 pyparsing==3.0.7
@@ -62,13 +82,17 @@ pytz==2021.3
     #   djangorestframework
 rules==3.1
     # via -r requirements/test.in
+six==1.16.0
+    # via
+    #   -r requirements/base.txt
+    #   click-repl
 sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
 testfixtures==6.18.3
     # via -r requirements/test.in
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   coverage
     #   pytest
@@ -76,3 +100,11 @@ tomli==2.0.0
     #   -r requirements/base.txt
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via
+    #   -r requirements/base.txt
+    #   prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,25 @@
 [tox]
-envlist = py38-django{32,40}-celery{44,50}-drf{312,latest},quality,docs
+envlist = py38-django{32,40}-celery{44,52}-drf{312,latest},quality,docs
 
 [testenv]
-deps = 
+deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     drf312: djangorestframework>=3.12,<3.13
     drflatest: djangorestframework
     celery44: -r{toxinidir}/requirements/celery44.txt
-    celery50: -r{toxinidir}/requirements/celery50.txt
+    celery52: -r{toxinidir}/requirements/celery52.txt
     -r{toxinidir}/requirements/test.txt
-commands = 
+commands =
     python -Wd -m pytest {posargs}
 
 [testenv:docs]
-allowlist_externals = 
+allowlist_externals =
     make
     rm
-deps = 
+deps =
     -r{toxinidir}/requirements/doc.txt
-commands = 
+commands =
     doc8 --ignore-path docs/_build --ignore-path docs/rest_api.rst README.rst docs
     rm -f docs/user_tasks.rst
     rm -f docs/modules.rst
@@ -29,17 +29,17 @@ commands =
     twine check dist/*
 
 [testenv:quality]
-setenv = 
+setenv =
     DJANGO_SETTINGS_MODULE=test_settings
-allowlist_externals = 
+allowlist_externals =
     make
     rm
     touch
-deps = 
+deps =
     -r{toxinidir}/requirements/doc.txt
     -r{toxinidir}/requirements/quality.txt
     -r{toxinidir}/requirements/test.txt
-commands = 
+commands =
     touch tests/__init__.py
     pylint user_tasks
     pylint tests

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,7 +4,7 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '2.2.0'
+__version__ = '3.0.0'
 
 default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 


### PR DESCRIPTION
## Description

This PR removes Celery<5 pin from requirements, so resolves a dependency conflict in https://github.com/openedx/edx-platform/pull/29046.

## Supporting information

For more information, please see the linked PR.