### PR TITLE
docs: Update the link to the contributing guidelines.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,10 +90,7 @@ How To Contribute
 
 Contributions are very welcome.
 
-Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
-
-Even though they were written with ``edx-platform`` in mind, the guidelines
-should be followed for Open edX code in general.
+Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`_ for details.
 
 Reporting Security Issues
 -------------------------


### PR DESCRIPTION
We're moving to a single standard set of guidelines across the whole
openedx organization.
