### PR TITLE
feat: Upgrade to Django 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [django32-celery44-drf312, django32-celery44-drflatest, django32-celery52-drf312,
-          django32-celery52-drflatest, django40-celery44-drf312, django40-celery44-drflatest,
-          django40-celery52-drf312, django40-celery52-drflatest, quality, docs]
+        toxenv: [
+            django32-celery53-drf313, django32-celery53-drflatest,
+            django42-celery53-drflatest,
+            quality, docs
+        ]
 
     steps:
     - uses: actions/checkout@v3
@@ -36,7 +38,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django32-celery52-drf312'
+      if: matrix.python-version == '3.8' && matrix.toxenv == 'django42-celery53-drflatest'
       uses: codecov/codecov-action@v3
       with:
         flags: unittests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,17 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+
+[3.1.0] - 2023-07-21
+~~~~~~~~~~~~~~~~~~~~
+
+Added
++++++
+* Added Django42 support in CI.
+* Removed old versions of celery and drf version from ci.
+
 Removed
 +++++++
-
 * Removed Python 3.5 support.
 
 Chore
@@ -24,6 +32,7 @@ Chore
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 * Upgraded celery to latest 5.x version.
+* Add Support for Django 4.2
 
 [2.2.0] - 2022-01-26
 ~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,18 @@ Unreleased
 Added
 +++++
 * Added Django42 support in CI.
+
+Removed
++++++++
 * Removed old versions of celery and drf version from ci.
+
+Chore
++++++
+* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
+  deprecated
+
+[3.0.0] - 2022-02-09
+~~~~~~~~~~~~~~~~~~~~
 
 Removed
 +++++++
@@ -29,10 +40,7 @@ Removed
 
 Chore
 +++++
-* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
-  deprecated
 * Upgraded celery to latest 5.x version.
-* Add Support for Django 4.2
 
 [2.2.0] - 2022-01-26
 ~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -75,19 +75,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django, djangorestframework, and celery versions for tests
-	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery52.txt
 	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
 	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
-	sed -i.tmp '/^amqp==/d' requirements/test.txt
-	sed -i.tmp '/^anyjson==/d' requirements/test.txt
-	sed -i.tmp '/^billiard==/d' requirements/test.txt
-	sed -i.tmp '/^celery==/d' requirements/test.txt
-	sed -i.tmp '/^kombu==/d' requirements/test.txt
-	sed -i.tmp '/^vine==/d' requirements/test.txt
-	sed -i.tmp '/^click-didyoumean==/d' requirements/test.txt
-	sed -i.tmp '/^click==/d' requirements/test.txt
-	sed -i.tmp '/^prompt-toolkit==/d' requirements/test.txt
-
 	rm requirements/test.txt.tmp
 
 pull_translations: ## pull translations from Transifex

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-click==8.1.4
+click==8.1.6
     # via
     #   celery
     #   click-didyoumean
@@ -43,7 +43,7 @@ djangorestframework==3.14.0
     # via
     #   -r requirements/base.in
     #   drf-yasg
-drf-yasg==1.21.6
+drf-yasg==1.21.7
     # via -r requirements/base.in
 inflection==0.5.1
     # via drf-yasg

--- a/requirements/celery44.txt
+++ b/requirements/celery44.txt
@@ -1,5 +1,0 @@
-amqp==2.6.1
-billiard==3.6.4.0
-celery==4.4.7
-kombu==4.6.11
-vine==1.3.0

--- a/requirements/celery52.txt
+++ b/requirements/celery52.txt
@@ -1,9 +1,0 @@
-amqp==5.1.1
-billiard==4.1.0
-celery==5.3.1
-click==8.1.4
-click-didyoumean==0.3.0
-click-repl==0.3.0
-kombu==5.3.1
-prompt-toolkit==3.0.39
-vine==5.0.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
 filelock==3.12.2
     # via
@@ -12,7 +12,7 @@ filelock==3.12.2
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.8.1
+platformdirs==3.9.1
     # via virtualenv
 pluggy==1.2.0
     # via tox
@@ -29,5 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-virtualenv==20.23.1
+virtualenv==20.24.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,7 +34,7 @@ celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-click==8.1.4
+click==8.1.6
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -63,7 +63,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/test.txt
     #   celery
-code-annotations==1.3.0
+code-annotations==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -75,7 +75,7 @@ dill==0.3.6
     # via
     #   -r requirements/quality.txt
     #   pylint
-distlib==0.3.6
+distlib==0.3.7
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -93,7 +93,7 @@ djangorestframework==3.14.0
     # via
     #   -r requirements/test.txt
     #   drf-yasg
-drf-yasg==1.21.6
+drf-yasg==1.21.7
     # via -r requirements/test.txt
 edx-i18n-tools==1.0.0
     # via -r requirements/dev.in
@@ -142,7 +142,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-mock==5.0.2
+mock==5.1.0
     # via -r requirements/test.txt
 packaging==23.1
     # via
@@ -159,9 +159,9 @@ pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pip-tools==6.14.0
+pip-tools==7.1.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.8.1
+platformdirs==3.9.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -317,7 +317,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.23.1
+virtualenv==20.24.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -325,7 +325,7 @@ wcwidth==0.2.6
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
-wheel==0.40.0
+wheel==0.41.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -43,13 +43,13 @@ celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-certifi==2023.5.7
+certifi==2023.7.22
     # via requests
 cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
-click==8.1.4
+click==8.1.6
     # via
     #   -r requirements/base.txt
     #   celery
@@ -74,7 +74,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==41.0.1
+cryptography==41.0.2
     # via secretstorage
 django==3.2.20
     # via
@@ -101,7 +101,7 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-drf-yasg==1.21.6
+drf-yasg==1.21.7
     # via -r requirements/base.txt
 idna==3.4
     # via requests
@@ -134,9 +134,9 @@ jinja2==3.1.2
     #   coreschema
     #   sphinx
     #   swagger2rst
-jsonschema==4.18.0
+jsonschema==4.18.4
     # via swagger2rst
-jsonschema-specifications==2023.6.1
+jsonschema-specifications==2023.7.1
     # via jsonschema
 keyring==24.2.0
     # via twine
@@ -201,7 +201,7 @@ pyyaml==5.4.1
     #   swagger2rst
 readme-renderer==40.0
     # via twine
-referencing==0.29.1
+referencing==0.30.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -219,7 +219,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.4.2
     # via twine
-rpds-py==0.8.10
+rpds-py==0.9.2
     # via
     #   jsonschema
     #   referencing
@@ -288,7 +288,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.0.3
+urllib3==2.0.4
     # via
     #   requests
     #   twine
@@ -304,7 +304,7 @@ wcwidth==0.2.6
     #   prompt-toolkit
 webencodings==0.5.1
     # via bleach
-zipp==3.16.0
+zipp==3.16.2
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,11 +6,11 @@
 #
 build==0.10.0
     # via pip-tools
-click==8.1.4
+click==8.1.6
     # via pip-tools
 packaging==23.1
     # via build
-pip-tools==6.14.0
+pip-tools==7.1.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build
@@ -18,7 +18,7 @@ tomli==2.0.1
     # via
     #   build
     #   pip-tools
-wheel==0.40.0
+wheel==0.41.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.40.0
+wheel==0.41.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.1.2
+pip==23.2.1
     # via -r requirements/pip.in
 setuptools==68.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,14 +8,14 @@ astroid==2.15.6
     # via
     #   pylint
     #   pylint-celery
-click==8.1.4
+click==8.1.6
     # via
     #   click-log
     #   code-annotations
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.3.0
+code-annotations==1.5.0
     # via edx-lint
 dill==0.3.6
     # via pylint
@@ -35,7 +35,7 @@ mccabe==0.7.0
     # via pylint
 pbr==5.11.1
     # via stevedore
-platformdirs==3.8.1
+platformdirs==3.9.1
     # via pylint
 pycodestyle==2.10.0
     # via -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+amqp==5.1.1
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -16,18 +17,22 @@ backports-zoneinfo[tzdata]==0.2.1
     #   -r requirements/base.txt
     #   celery
     #   kombu
+billiard==4.1.0
     # via
     #   -r requirements/base.txt
     #   celery
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+click==8.1.6
     # via
     #   -r requirements/base.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+click-didyoumean==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
@@ -52,7 +57,7 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
-drf-yasg==1.21.6
+drf-yasg==1.21.7
     # via -r requirements/base.txt
 exceptiongroup==1.1.2
     # via pytest
@@ -62,10 +67,11 @@ inflection==0.5.1
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
+kombu==5.3.1
     # via
     #   -r requirements/base.txt
     #   celery
-mock==5.0.2
+mock==5.1.0
     # via -r requirements/test.in
 packaging==23.1
     # via
@@ -75,6 +81,7 @@ packaging==23.1
     #   pytest
 pluggy==1.2.0
     # via pytest
+prompt-toolkit==3.0.39
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -131,6 +138,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
+vine==5.0.0
     # via
     #   -r requirements/base.txt
     #   amqp

--- a/schema/urls.py
+++ b/schema/urls.py
@@ -5,8 +5,8 @@ URLs for REST API schema generation.
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, re_path
 
 from rest_framework import permissions
 
@@ -24,7 +24,7 @@ SCHEMA = get_schema_view(
 
 # The Swagger/Open API JSON file can be found at http://localhost:8000/?format=openapi
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^swagger(?P<format>\.json|\.yaml)$', SCHEMA.without_ui(cache_timeout=0), name='schema-json'),
-    url(r'^swagger/$', SCHEMA.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+   re_path(r'^admin/', include(admin.site.urls)),
+   re_path(r'^swagger(?P<format>\.json|\.yaml)$', SCHEMA.without_ui(cache_timeout=0), name='schema-json'),
+   re_path(r'^swagger/$', SCHEMA.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ] + base_patterns

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Framework :: Django',
         'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
-envlist = py38-django{32,40}-celery{44,52}-drf{312,latest},quality,docs
+envlist =
+    py38-django{32,42}-celery{53}-drf{313,latest}
+    quality
+    docs
 
 [testenv]
 deps =
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
-    drf312: djangorestframework>=3.12,<3.13
+    django42: Django>=4.2,<4.3
+    drf313: djangorestframework>=3.13,<3.14
     drflatest: djangorestframework
-    celery44: -r{toxinidir}/requirements/celery44.txt
-    celery52: -r{toxinidir}/requirements/celery52.txt
     -r{toxinidir}/requirements/test.txt
 commands =
     python -Wd -m pytest --cov user_tasks {posargs}

--- a/user_tasks/__init__.py
+++ b/user_tasks/__init__.py
@@ -4,9 +4,8 @@ Management of user-triggered asynchronous tasks in Django projects.
 
 from django.dispatch import Signal
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
-default_app_config = 'user_tasks.apps.UserTasksConfig'  # pylint: disable=invalid-name
 
 # This signal is emitted when a user task reaches any final state:
 # SUCCEEDED, FAILED, or CANCELED

--- a/user_tasks/admin.py
+++ b/user_tasks/admin.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from .models import UserTaskArtifact, UserTaskStatus
 
 
+@admin.register(UserTaskArtifact)
 class UserTaskArtifactAdmin(admin.ModelAdmin):
     """
     Configuration for UserTaskArtifact admin panel.
@@ -19,6 +20,7 @@ class UserTaskArtifactAdmin(admin.ModelAdmin):
     raw_id_fields = ('status',)
 
 
+@admin.register(UserTaskStatus)
 class UserTaskStatusAdmin(admin.ModelAdmin):
     """
     Configuration for UserTaskStatus admin panel.
@@ -31,7 +33,3 @@ class UserTaskStatusAdmin(admin.ModelAdmin):
         'uuid', 'task_id', 'task_class', 'name', 'user__username', 'user__email'
     )
     readonly_fields = ('parent', )
-
-
-admin.site.register(UserTaskArtifact, UserTaskArtifactAdmin)
-admin.site.register(UserTaskStatus, UserTaskStatusAdmin)


### PR DESCRIPTION
Issue: https://github.com/edx/upgrades/issues/134
Upgrade to Django 4.2
Django42 will work with `drf==3.14.0`. We are using only compatible versions for tests.
Removed celery other versions since `edx-platform` is already using latest celery version.
