### PR TITLE
build: Update codecov and use token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
 
     - name: Run coverage
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django42-celery53-drflatest'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
-        fail_ci_if_error: false
-
+        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         - '3.8'
         - '3.11'
         - '3.12'
-        toxenv: [django42-celery53-drflatest, django42-celery53-drflatest,
+        toxenv: [django42-celery53-drflatest,
           quality, docs, django42]
 
     steps:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ django==4.2.13
     #   drf-yasg
 django-model-utils==4.5.1
     # via -r requirements/base.in
-djangorestframework==3.15.1
+djangorestframework==3.15.2
     # via
     #   -r requirements/base.in
     #   drf-yasg

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,3 +2,4 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
+coverage                  # to capture code coverage information

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,9 +10,11 @@ chardet==5.2.0
     # via tox
 colorama==0.4.6
     # via tox
+coverage==7.5.3
+    # via -r requirements/ci.in
 distlib==0.3.8
     # via virtualenv
-filelock==3.15.1
+filelock==3.15.4
     # via
     #   tox
     #   virtualenv
@@ -26,7 +28,7 @@ platformdirs==4.2.2
     #   virtualenv
 pluggy==1.5.0
     # via tox
-pyproject-api==1.6.1
+pyproject-api==1.7.1
     # via tox
 tomli==2.0.1
     # via
@@ -34,5 +36,5 @@ tomli==2.0.1
     #   tox
 tox==4.15.1
     # via -r requirements/ci.in
-virtualenv==20.26.2
+virtualenv==20.26.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -84,6 +84,7 @@ colorama==0.4.6
     #   tox
 coverage[toml]==7.5.3
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pytest-cov
 dill==0.3.8
@@ -104,7 +105,7 @@ django==4.2.13
     #   edx-i18n-tools
 django-model-utils==4.5.1
     # via -r requirements/test.txt
-djangorestframework==3.15.1
+djangorestframework==3.15.2
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -120,7 +121,7 @@ exceptiongroup==1.2.1
     # via
     #   -r requirements/test.txt
     #   pytest
-filelock==3.15.1
+filelock==3.15.4
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -227,7 +228,7 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pyproject-api==1.6.1
+pyproject-api==1.7.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -332,7 +333,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.26.2
+virtualenv==20.26.3
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -90,7 +90,7 @@ django-model-utils==4.5.1
     # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/doc.in
-djangorestframework==3.15.1
+djangorestframework==3.15.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -307,7 +307,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   requests
     #   twine

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.43.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.0
+pip==24.1
     # via -r requirements/pip.in
-setuptools==70.0.0
+setuptools==70.1.0
     # via -r requirements/pip.in


### PR DESCRIPTION
Update codecov to the latest version and start using the org-wide token for uploads.

See https://github.com/openedx/wg-frontend/issues/179
