### PR TITLE
fix(signals): support Celery protocol v2 in create_user_task

### DIFF
--- a/user_tasks/signals.py
+++ b/user_tasks/signals.py
@@ -5,6 +5,7 @@ Celery signal handlers and custom Django signal.
 import logging
 from uuid import uuid4
 
+from celery import current_app as celery_app
 from celery.signals import before_task_publish, task_failure, task_prerun, task_retry, task_success
 
 from django.contrib.auth import get_user_model
@@ -16,40 +17,50 @@ from user_tasks import user_task_stopped
 from .exceptions import TaskCanceledException
 from .models import UserTaskStatus
 from .tasks import UserTaskMixin
+from .utils import proto2_to_proto1
 
 LOGGER = logging.getLogger(__name__)
 
 
 @before_task_publish.connect
-def create_user_task(sender=None, body=None, **kwargs):
+def create_user_task(sender=None, body=None, headers=None, **kwargs):
     """
     Create a :py:class:`UserTaskStatus` record for each :py:class:`UserTaskMixin`.
 
     Also creates a :py:class:`UserTaskStatus` for each chain, chord, or group containing
     the new :py:class:`UserTaskMixin`.
+
+    Supports Celery protocol v1 and v2.
     """
+
     try:
         task_class = import_string(sender)
     except ImportError:
         return
-    if issubclass(task_class.__class__, UserTaskMixin):
-        arguments_dict = task_class.arguments_as_dict(*body['args'], **body['kwargs'])
-        user_id = _get_user_id(arguments_dict)
-        task_id = body['id']
-        if body.get('callbacks', []):
-            _create_chain_entry(user_id, task_id, task_class, body['args'], body['kwargs'], body['callbacks'])
-            return
-        if body.get('chord', None):
-            _create_chord_entry(task_id, task_class, body, user_id)
-            return
-        parent = _get_or_create_group_parent(body, user_id)
-        name = task_class.generate_name(arguments_dict)
-        total_steps = task_class.calculate_total_steps(arguments_dict)
-        UserTaskStatus.objects.get_or_create(
-            task_id=task_id, defaults={'user_id': user_id, 'parent': parent, 'name': name, 'task_class': sender,
-                                       'total_steps': total_steps})
-        if parent:
-            parent.increment_total_steps(total_steps)
+
+    if celery_app.conf.task_protocol == 2:
+        body = proto2_to_proto1(body, headers or {})
+
+    if not issubclass(task_class.__class__, UserTaskMixin):
+        return
+
+    arguments_dict = task_class.arguments_as_dict(*body['args'], **body['kwargs'])
+    user_id = _get_user_id(arguments_dict)
+    task_id = body['id']
+    if body.get('callbacks', []):
+        _create_chain_entry(user_id, task_id, task_class, body['args'], body['kwargs'], body['callbacks'])
+        return
+    if body.get('chord', None):
+        _create_chord_entry(task_id, task_class, body, user_id)
+        return
+    parent = _get_or_create_group_parent(body, user_id)
+    name = task_class.generate_name(arguments_dict)
+    total_steps = task_class.calculate_total_steps(arguments_dict)
+    UserTaskStatus.objects.get_or_create(
+        task_id=task_id, defaults={'user_id': user_id, 'parent': parent, 'name': name, 'task_class': sender,
+                                    'total_steps': total_steps})
+    if parent:
+        parent.increment_total_steps(total_steps)
 
 
 def _create_chain_entry(user_id, task_id, task_class, args, kwargs, callbacks, parent=None):

--- a/user_tasks/utils.py
+++ b/user_tasks/utils.py
@@ -1,0 +1,51 @@
+"""
+Utility functions for handling Celery task protocol compatibility.
+"""
+
+from celery import chain
+
+
+def proto2_to_proto1(body, headers):
+    """
+    Convert a protocol v2 task body and headers to protocol v1 format.
+    """
+    args, kwargs, embed = body
+    embedded = extract_proto2_embed(**embed)
+    chained = embedded.pop("chain", None)
+    new_body = dict(
+        extract_proto2_headers(**headers),
+        args=args,
+        kwargs=kwargs,
+        **embedded,
+    )
+    if chained:
+        new_body["callbacks"].append(chain(chained))
+    return new_body
+
+
+def extract_proto2_headers(id, retries, eta, expires, group, timelimit, task, **_):
+    """
+    Extract relevant headers from protocol v2 format.
+    """
+    return {
+        "id": id,
+        "task": task,
+        "retries": retries,
+        "eta": eta,
+        "expires": expires,
+        "utc": True,
+        "taskset": group,
+        "timelimit": timelimit,
+    }
+
+
+def extract_proto2_embed(callbacks=None, errbacks=None, chain=None, chord=None, **_):
+    """
+    Extract embedded task metadata.
+    """
+    return {
+        "callbacks": callbacks or [],
+        "errbacks": errbacks or [],
+        "chain": chain,
+        "chord": chord,
+    }


### PR DESCRIPTION
### What are the relevant tickets?
[#232](https://github.com/openedx/django-user-tasks/issues/232)

### Description (What does it do?)

This PR fixes a compatibility issue with the create_user_task signal handler when using Celery's task message protocol version 2, which has been the default for several years.

Currently, the signal handler fails with the following error:

`TypeError: tuple indices must be integers or slices, not str`

This occurs because the handler expects a protocol v1-style task body (a dictionary), while protocol v2 passes the body as a tuple. Although the exception is caught and logged internally by Celery, it might be preventing UserTaskStatus from being created reliably in affected cases.

#### Changes
The changes mainly follows the workaround suggested in the issue:
- Updated create_user_task to detect the task protocol version and normalize the body to the expected format.
- Added utility functions to convert protocol v2 bodies and headers into a protocol v1-compatible structure.
- Ensured backward compatibility with protocol v1.